### PR TITLE
refactor: resolve missing dependencies and stubs

### DIFF
--- a/HuaweiUnlock/DIAGNOS/DataS.cs
+++ b/HuaweiUnlock/DIAGNOS/DataS.cs
@@ -8,6 +8,29 @@ namespace HuaweiUnlocker.DIAGNOS
         public const string MTK_firmwareupgrade = "firmware_upgrade";
         public const string MTK_formatallanddload = "fm_and_dl";
         public const string MTK_formatall = "fm";
+
+        public struct CMD_PKT
+        {
+            private byte[] _data;
+            public CMD_PKT(int size, params string[] parts)
+            {
+                string hex = string.Concat(parts ?? Array.Empty<string>());
+                _data = HexStringToBytes(hex);
+                if (size > 0 && _data.Length < size)
+                    Array.Resize(ref _data, size);
+            }
+            public byte[] GetBytes() => _data ?? Array.Empty<byte>();
+        }
+
+        private static byte[] HexStringToBytes(string hex)
+        {
+            if (string.IsNullOrEmpty(hex)) return Array.Empty<byte>();
+            int len = hex.Length / 2;
+            byte[] bytes = new byte[len];
+            for (int i = 0; i < len; i++)
+                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            return bytes;
+        }
         public struct GPT_Struct
         {
             public int StartAdress;

--- a/HuaweiUnlock/HuaweiUnlock.csproj
+++ b/HuaweiUnlock/HuaweiUnlock.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>HuaweiUnlock</RootNamespace>
     <AssemblyName>HuaweiUnlock</AssemblyName>
     <StartupObject>HuaweiUnlocker.Program</StartupObject>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +16,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="System.IO.Ports" Version="7.0.0" />
+    <PackageReference Include="Base62" Version="1.3.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/HuaweiUnlock/LangProc.cs
+++ b/HuaweiUnlock/LangProc.cs
@@ -1,63 +1,59 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Runtime.Serialization.Formatters.Binary;
+using HuaweiUnlocker.UI;
+using System;
 using System.Windows.Forms;
-using Witcher3_Multiplayer.ClientHost;
 
-namespace Witcher3_Multiplayer
+namespace HuaweiUnlocker
 {
-    public static class langproc
+    public static class LangProc
     {
-        public static TextBox LOGGERB;
-        public static bool IsHost = false,
-            Dedicated = false,
-            IsConnected = false,
-            TESTMYCLIENT = false,
-            debug = true;
-        public static double VersionCur = 1.0;
-        public static int SendDataDelay = 16;
-        public static Main MForm;
-        public static SimpleOverlayFORWINDOWEDMODE OverlForm;
-        public static string MonstersPath = "characters\\npc_entities\\monsters\\";//+MONSTERNAME
-        public static Dictionary<int, PlayerData> PlayerDataClient = new Dictionary<int, PlayerData>();
-        public static Dictionary<int, PlayerData> PlayerDataServerDATAS = new Dictionary<int, PlayerData>();
-        public static Dictionary<IPEndPoint, int> PlayerDataServer = new Dictionary<IPEndPoint, int>();
-        public static void LOG(string s)
+        public static bool debug = true;
+        public static TabControl Tab;
+        public static TextBox LOGGBOX;
+        public static NProgressBar PRG;
+
+        public static bool LOG(int type, string message = "", object extra = null)
         {
-            Action t = () => {
-                LOGGERB.Text += ("[INFO] " + s + Environment.NewLine);
-                LOGGERB.SelectionStart = LOGGERB.Text.Length;
-                LOGGERB.ScrollToCaret(); 
+            string prefix = type switch
+            {
+                1 => "[WARN] ",
+                2 => "[ERROR] ",
+                _ => "[INFO] "
             };
-            if (LOGGERB.InvokeRequired)
-                LOGGERB.Invoke(t);
-            else
-                t();
+            string text = prefix + message + (extra != null ? extra.ToString() : string.Empty);
+            if (LOGGBOX != null)
+            {
+                Action act = () =>
+                {
+                    LOGGBOX.AppendText(text + Environment.NewLine);
+                    LOGGBOX.SelectionStart = LOGGBOX.Text.Length;
+                    LOGGBOX.ScrollToCaret();
+                };
+                if (LOGGBOX.InvokeRequired) LOGGBOX.Invoke(act); else act();
+            }
+            return type == 0;
         }
-        public static void ELOG(string s)
+
+        public static void Progress(int value)
         {
-            Action t = () => { LOGGERB.Text += "[ERROR] " + s + Environment.NewLine; };
-            if (LOGGERB.InvokeRequired)
-                LOGGERB.Invoke(t);
-            else
-                t();
+            if (PRG == null) return;
+            Action act = () =>
+            {
+                value = Math.Max(PRG.ValueMinimum, Math.Min(value, PRG.ValueMaximum));
+                PRG.Value = value;
+            };
+            if (PRG.InvokeRequired) PRG.Invoke(act); else act();
         }
-        public static byte[] ToByteArray(this object structure)
+
+        public static void Progress(int value, int max)
         {
-            BinaryFormatter bf = new BinaryFormatter();
-            MemoryStream ms = new MemoryStream();
-            bf.Serialize(ms, structure);
-            return ms.ToArray();
-        }
-        public static T ToStructure<T>(this byte[] arrBytes) where T : struct
-        {
-            MemoryStream memStream = new MemoryStream(arrBytes);
-            BinaryFormatter binForm = new BinaryFormatter();
-            memStream.Seek(0, SeekOrigin.Begin);
-            T obj = (T)binForm.Deserialize(memStream);
-            return obj;
+            if (PRG == null) return;
+            Action act = () =>
+            {
+                PRG.ValueMaximum = max;
+                value = Math.Max(PRG.ValueMinimum, Math.Min(value, PRG.ValueMaximum));
+                PRG.Value = value;
+            };
+            if (PRG.InvokeRequired) PRG.Invoke(act); else act();
         }
     }
 }

--- a/HuaweiUnlock/Modules/Core/LoaderManager.cs
+++ b/HuaweiUnlock/Modules/Core/LoaderManager.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web.Script.Serialization;
+using Newtonsoft.Json;
 using System.Windows.Forms;
 
 namespace HuaweiUnlocker.Modules.Core
@@ -15,7 +15,7 @@ namespace HuaweiUnlocker.Modules.Core
         public static readonly string ManifestPath = Path.Combine(Root, "loaders.json");
 
         private static LoaderManifest _manifest = new LoaderManifest();
-        private static readonly JavaScriptSerializer _json = new JavaScriptSerializer();
+        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
 
         public static LoaderManifest Manifest => _manifest;
 
@@ -37,7 +37,7 @@ namespace HuaweiUnlocker.Modules.Core
                 if (File.Exists(ManifestPath))
                 {
                     var txt = File.ReadAllText(ManifestPath);
-                    _manifest = _json.Deserialize<LoaderManifest>(txt) ?? new LoaderManifest();
+                    _manifest = JsonConvert.DeserializeObject<LoaderManifest>(txt, _jsonSettings) ?? new LoaderManifest();
                 }
             }
             catch
@@ -49,7 +49,7 @@ namespace HuaweiUnlocker.Modules.Core
         public static void Save()
         {
             EnsureFolders();
-            var txt = _json.Serialize(_manifest);
+            var txt = JsonConvert.SerializeObject(_manifest, _jsonSettings);
             File.WriteAllText(ManifestPath, txt);
         }
 


### PR DESCRIPTION
## Summary
- replace leftover LangProc with internal logger/progress helper
- add CMD_PKT struct and hex helpers in DataS
- switch LoaderManager to Newtonsoft.Json serialization
- include missing package references and build properties

## Testing
- `dotnet build HuaweiUnlock.sln` *(fails: DeviceInfo, CurTask, etc. undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a42b30132083269f05fa4c7244f9cc